### PR TITLE
Add structure templates for LaS Trees

### DIFF
--- a/assets/prefabs/structures/BlackRedTree.prefab
+++ b/assets/prefabs/structures/BlackRedTree.prefab
@@ -1,0 +1,147 @@
+{
+  "StructureTemplate": {},
+  "SpawnBlockRegions": {
+    "regionsToFill": [
+      {
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "region": { "min": [-3, 2, -3], "size": [8, 1, 3] }
+      },
+      {
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "region": { "min": [-2, 3, -2], "size": [6, 1, 1] }
+      },
+      {
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "region": { "min": [-2, 3, -1], "size": [1, 1, 3] }
+      },
+      {
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "region": { "min": [-1, 4, -1], "size": [4, 1, 1] }
+      },
+      {
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "region": { "min": [3, 3, -1], "size": [1, 1, 4] }
+      },
+      {
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "region": { "min": [-3, 2, 0], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "region": { "min": [-1, 4, 0], "size": [1, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "region": { "min": [0, 5, 0], "size": [2, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "region": { "min": [2, 2, 0], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "region": { "min": [2, 4, 0], "size": [1, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "region": { "min": [-3, 2, 2], "size": [8, 1, 3] }
+      },
+      {
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "region": { "min": [-2, 3, 2], "size": [2, 1, 1] }
+      },
+      {
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "region": { "min": [-1, 4, 2], "size": [4, 1, 1] }
+      },
+      {
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "region": { "min": [-2, 3, 3], "size": [6, 1, 1] }
+      },
+      {
+        "blockType": "LightAndShadowResources:RedFloorBlock",
+        "region": { "min": [0, 0, 0], "size": [2, 5, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 0, -3], "size": [8, 2, 3] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 3, -3], "size": [8, 3, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 3, -2], "size": [1, 1, 6] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 4, -2], "size": [8, 2, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [4, 3, -2], "size": [1, 1, 6] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 4, -1], "size": [2, 1, 4] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 5, -1], "size": [8, 1, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-1, 3, -1], "size": [4, 1, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [3, 4, -1], "size": [2, 1, 4] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 0, 0], "size": [3, 2, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 5, 0], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-1, 3, 0], "size": [1, 1, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [2, 0, 0], "size": [3, 2, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [2, 3, 0], "size": [1, 1, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [2, 5, 0], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 0, 2], "size": [8, 2, 3] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 5, 2], "size": [8, 1, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [0, 3, 2], "size": [3, 1, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 4, 3], "size": [8, 2, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 3, 4], "size": [8, 3, 1] }
+      }
+    ]
+  }
+}

--- a/assets/prefabs/structures/BlackWhiteTree.prefab
+++ b/assets/prefabs/structures/BlackWhiteTree.prefab
@@ -1,0 +1,163 @@
+{
+  "StructureTemplate": {},
+  "SpawnBlockRegions": {
+    "regionsToFill": [
+      {
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "region": { "min": [-3, 2, -4], "size": [8, 1, 3] }
+      },
+      {
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "region": { "min": [-2, 3, -3], "size": [6, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "region": { "min": [-1, 4, -2], "size": [4, 1, 1] }
+      },
+      {
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "region": { "min": [-3, 2, -1], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "region": { "min": [-2, 3, -1], "size": [2, 1, 1] }
+      },
+      {
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "region": { "min": [-1, 4, -1], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "region": { "min": [0, 5, -1], "size": [2, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "region": { "min": [2, 2, -1], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "region": { "min": [2, 3, -1], "size": [2, 1, 1] }
+      },
+      {
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "region": { "min": [2, 4, -1], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "region": { "min": [-2, 3, 0], "size": [6, 1, 3] }
+      },
+      {
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "region": { "min": [-1, 4, 0], "size": [4, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "region": { "min": [-3, 2, 1], "size": [8, 1, 3] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [0, 0, -1], "size": [2, 3, 2] }
+      },
+      {
+        "blockType": "core:TallGrass1",
+        "region": { "min": [-2, 0, -4], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "core:TallGrass2",
+        "region": { "min": [4, 0, -4], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "core:TallGrass3",
+        "region": { "min": [-3, 0, -2], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 0, -4], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 1, -4], "size": [8, 1, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 3, -4], "size": [8, 3, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-1, 0, -4], "size": [5, 1, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 0, -3], "size": [8, 2, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 3, -3], "size": [1, 1, 6] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 4, -3], "size": [8, 2, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [4, 3, -3], "size": [1, 1, 6] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 1, -2], "size": [8, 1, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 4, -2], "size": [2, 1, 4] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 5, -2], "size": [8, 1, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-2, 0, -2], "size": [7, 1, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [3, 4, -2], "size": [2, 1, 4] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 0, -1], "size": [3, 2, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 5, -1], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [0, 3, -1], "size": [2, 2, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [2, 0, -1], "size": [3, 2, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [2, 5, -1], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 0, 1], "size": [8, 2, 3] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 5, 1], "size": [8, 1, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 4, 2], "size": [8, 2, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 3, 3], "size": [8, 3, 1] }
+      }
+    ]
+  }
+}

--- a/assets/prefabs/structures/BlackWhiteTree.prefab
+++ b/assets/prefabs/structures/BlackWhiteTree.prefab
@@ -59,15 +59,15 @@
         "region": { "min": [0, 0, -1], "size": [2, 3, 2] }
       },
       {
-        "blockType": "core:TallGrass1",
+        "blockType": "engine:air",
         "region": { "min": [-2, 0, -4], "size": [1, 1, 1] }
       },
       {
-        "blockType": "core:TallGrass2",
+        "blockType": "engine:air",
         "region": { "min": [4, 0, -4], "size": [1, 1, 1] }
       },
       {
-        "blockType": "core:TallGrass3",
+        "blockType": "engine:air",
         "region": { "min": [-3, 0, -2], "size": [1, 1, 1] }
       },
       {

--- a/assets/prefabs/structures/RedBlackTree.prefab
+++ b/assets/prefabs/structures/RedBlackTree.prefab
@@ -3,59 +3,59 @@
   "SpawnBlockRegions": {
     "regionsToFill": [
       {
-        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "blockType": "LightAndShadowResources:RedFloorBlock",
         "region": { "min": [-3, 2, -4], "size": [8, 1, 3] }
       },
       {
-        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "blockType": "LightAndShadowResources:RedFloorBlock",
         "region": { "min": [-2, 3, -3], "size": [6, 1, 2] }
       },
       {
-        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "blockType": "LightAndShadowResources:RedFloorBlock",
         "region": { "min": [-1, 4, -2], "size": [4, 1, 1] }
       },
       {
-        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "blockType": "LightAndShadowResources:RedFloorBlock",
         "region": { "min": [-3, 2, -1], "size": [3, 1, 2] }
       },
       {
-        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "blockType": "LightAndShadowResources:RedFloorBlock",
         "region": { "min": [-2, 3, -1], "size": [2, 1, 1] }
       },
       {
-        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "blockType": "LightAndShadowResources:RedFloorBlock",
         "region": { "min": [-1, 4, -1], "size": [1, 1, 1] }
       },
       {
-        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "blockType": "LightAndShadowResources:RedFloorBlock",
         "region": { "min": [0, 5, -1], "size": [2, 1, 2] }
       },
       {
-        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "blockType": "LightAndShadowResources:RedFloorBlock",
         "region": { "min": [2, 2, -1], "size": [3, 1, 2] }
       },
       {
-        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "blockType": "LightAndShadowResources:RedFloorBlock",
         "region": { "min": [2, 3, -1], "size": [2, 1, 1] }
       },
       {
-        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "blockType": "LightAndShadowResources:RedFloorBlock",
         "region": { "min": [2, 4, -1], "size": [1, 1, 1] }
       },
       {
-        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "blockType": "LightAndShadowResources:RedFloorBlock",
         "region": { "min": [-2, 3, 0], "size": [6, 1, 3] }
       },
       {
-        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "blockType": "LightAndShadowResources:RedFloorBlock",
         "region": { "min": [-1, 4, 0], "size": [4, 1, 2] }
       },
       {
-        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "blockType": "LightAndShadowResources:RedFloorBlock",
         "region": { "min": [-3, 2, 1], "size": [8, 1, 3] }
       },
       {
-        "blockType": "LightAndShadowResources:RedFloorBlock",
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
         "region": { "min": [0, 0, -1], "size": [2, 3, 2] }
       },
       {

--- a/assets/prefabs/structures/RedWhiteTree.prefab
+++ b/assets/prefabs/structures/RedWhiteTree.prefab
@@ -4,123 +4,159 @@
     "regionsToFill": [
       {
         "blockType": "LightAndShadowResources:RedFloorBlock",
-        "region": { "min": [-4, 2, -4], "size": [8, 1, 3] }
+        "region": { "min": [-3, 2, -4], "size": [8, 1, 3] }
       },
       {
         "blockType": "LightAndShadowResources:RedFloorBlock",
-        "region": { "min": [-3, 3, -3], "size": [6, 1, 2] }
+        "region": { "min": [-2, 3, -3], "size": [6, 1, 2] }
       },
       {
         "blockType": "LightAndShadowResources:RedFloorBlock",
-        "region": { "min": [-2, 4, -2], "size": [4, 1, 1] }
+        "region": { "min": [-1, 4, -2], "size": [4, 1, 1] }
       },
       {
         "blockType": "LightAndShadowResources:RedFloorBlock",
-        "region": { "min": [-4, 2, -1], "size": [3, 1, 2] }
+        "region": { "min": [-3, 2, -1], "size": [3, 1, 2] }
       },
       {
         "blockType": "LightAndShadowResources:RedFloorBlock",
-        "region": { "min": [-3, 3, -1], "size": [2, 1, 2] }
+        "region": { "min": [-2, 3, -1], "size": [2, 1, 1] }
       },
       {
         "blockType": "LightAndShadowResources:RedFloorBlock",
-        "region": { "min": [-2, 4, -1], "size": [1, 1, 2] }
+        "region": { "min": [-1, 4, -1], "size": [1, 1, 1] }
       },
       {
         "blockType": "LightAndShadowResources:RedFloorBlock",
-        "region": { "min": [-1, 5, -1], "size": [2, 1, 2] }
+        "region": { "min": [0, 5, -1], "size": [2, 1, 2] }
       },
       {
         "blockType": "LightAndShadowResources:RedFloorBlock",
-        "region": { "min": [1, 2, -1], "size": [3, 1, 2] }
+        "region": { "min": [2, 2, -1], "size": [3, 1, 2] }
       },
       {
         "blockType": "LightAndShadowResources:RedFloorBlock",
-        "region": { "min": [1, 3, -1], "size": [2, 1, 2] }
+        "region": { "min": [2, 3, -1], "size": [2, 1, 1] }
       },
       {
         "blockType": "LightAndShadowResources:RedFloorBlock",
-        "region": { "min": [1, 4, -1], "size": [1, 1, 2] }
+        "region": { "min": [2, 4, -1], "size": [1, 1, 1] }
       },
       {
         "blockType": "LightAndShadowResources:RedFloorBlock",
-        "region": { "min": [-4, 2, 1], "size": [8, 1, 3] }
+        "region": { "min": [-2, 3, 0], "size": [6, 1, 3] }
       },
       {
         "blockType": "LightAndShadowResources:RedFloorBlock",
-        "region": { "min": [-3, 3, 1], "size": [6, 1, 2] }
+        "region": { "min": [-1, 4, 0], "size": [4, 1, 2] }
       },
       {
         "blockType": "LightAndShadowResources:RedFloorBlock",
-        "region": { "min": [-2, 4, 1], "size": [4, 1, 1] }
+        "region": { "min": [-3, 2, 1], "size": [8, 1, 3] }
       },
       {
         "blockType": "LightAndShadowResources:whiteCenterBlock",
-        "region": { "min": [-1, 0, -1], "size": [2, 5, 2] }
+        "region": { "min": [0, 0, -1], "size": [2, 3, 2] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 0, -4], "size": [8, 2, 3] }
+        "region": { "min": [-2, 0, -4], "size": [1, 1, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 3, -4], "size": [8, 3, 1] }
+        "region": { "min": [4, 0, -4], "size": [1, 1, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 3, -3], "size": [1, 1, 6] }
+        "region": { "min": [-3, 0, -2], "size": [1, 1, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 4, -3], "size": [8, 2, 1] }
+        "region": { "min": [-3, 0, -4], "size": [1, 1, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [3, 3, -3], "size": [1, 1, 6] }
+        "region": { "min": [-3, 1, -4], "size": [8, 1, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 4, -2], "size": [2, 1, 4] }
+        "region": { "min": [-3, 3, -4], "size": [8, 3, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 5, -2], "size": [8, 1, 1] }
+        "region": { "min": [-1, 0, -4], "size": [5, 1, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [2, 4, -2], "size": [2, 1, 4] }
+        "region": { "min": [-3, 0, -3], "size": [8, 2, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 0, -1], "size": [3, 2, 2] }
+        "region": { "min": [-3, 3, -3], "size": [1, 1, 6] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 5, -1], "size": [3, 1, 2] }
+        "region": { "min": [-3, 4, -3], "size": [8, 2, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [1, 0, -1], "size": [3, 2, 2] }
+        "region": { "min": [4, 3, -3], "size": [1, 1, 6] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [1, 5, -1], "size": [3, 1, 2] }
+        "region": { "min": [-3, 1, -2], "size": [8, 1, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 0, 1], "size": [8, 2, 3] }
+        "region": { "min": [-3, 4, -2], "size": [2, 1, 4] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 5, 1], "size": [8, 1, 1] }
+        "region": { "min": [-3, 5, -2], "size": [8, 1, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 4, 2], "size": [8, 2, 1] }
+        "region": { "min": [-2, 0, -2], "size": [7, 1, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 3, 3], "size": [8, 3, 1] }
+        "region": { "min": [3, 4, -2], "size": [2, 1, 4] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 0, -1], "size": [3, 2, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 5, -1], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [0, 3, -1], "size": [2, 2, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [2, 0, -1], "size": [3, 2, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [2, 5, -1], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 0, 1], "size": [8, 2, 3] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 5, 1], "size": [8, 1, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 4, 2], "size": [8, 2, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 3, 3], "size": [8, 3, 1] }
       }
     ]
   }

--- a/assets/prefabs/structures/RedWhiteTree.prefab
+++ b/assets/prefabs/structures/RedWhiteTree.prefab
@@ -1,0 +1,127 @@
+{
+  "StructureTemplate": {},
+  "SpawnBlockRegions": {
+    "regionsToFill": [
+      {
+        "blockType": "LightAndShadowResources:RedFloorBlock",
+        "region": { "min": [-4, 2, -4], "size": [8, 1, 3] }
+      },
+      {
+        "blockType": "LightAndShadowResources:RedFloorBlock",
+        "region": { "min": [-3, 3, -3], "size": [6, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:RedFloorBlock",
+        "region": { "min": [-2, 4, -2], "size": [4, 1, 1] }
+      },
+      {
+        "blockType": "LightAndShadowResources:RedFloorBlock",
+        "region": { "min": [-4, 2, -1], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:RedFloorBlock",
+        "region": { "min": [-3, 3, -1], "size": [2, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:RedFloorBlock",
+        "region": { "min": [-2, 4, -1], "size": [1, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:RedFloorBlock",
+        "region": { "min": [-1, 5, -1], "size": [2, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:RedFloorBlock",
+        "region": { "min": [1, 2, -1], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:RedFloorBlock",
+        "region": { "min": [1, 3, -1], "size": [2, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:RedFloorBlock",
+        "region": { "min": [1, 4, -1], "size": [1, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:RedFloorBlock",
+        "region": { "min": [-4, 2, 1], "size": [8, 1, 3] }
+      },
+      {
+        "blockType": "LightAndShadowResources:RedFloorBlock",
+        "region": { "min": [-3, 3, 1], "size": [6, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:RedFloorBlock",
+        "region": { "min": [-2, 4, 1], "size": [4, 1, 1] }
+      },
+      {
+        "blockType": "LightAndShadowResources:whiteCenterBlock",
+        "region": { "min": [-1, 0, -1], "size": [2, 5, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 0, -4], "size": [8, 2, 3] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 3, -4], "size": [8, 3, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 3, -3], "size": [1, 1, 6] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 4, -3], "size": [8, 2, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [3, 3, -3], "size": [1, 1, 6] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 4, -2], "size": [2, 1, 4] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 5, -2], "size": [8, 1, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [2, 4, -2], "size": [2, 1, 4] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 0, -1], "size": [3, 2, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 5, -1], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [1, 0, -1], "size": [3, 2, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [1, 5, -1], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 0, 1], "size": [8, 2, 3] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 5, 1], "size": [8, 1, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 4, 2], "size": [8, 2, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 3, 3], "size": [8, 3, 1] }
+      }
+    ]
+  }
+}

--- a/assets/prefabs/structures/WhiteBlackTree.prefab
+++ b/assets/prefabs/structures/WhiteBlackTree.prefab
@@ -3,124 +3,160 @@
   "SpawnBlockRegions": {
     "regionsToFill": [
       {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-3, 2, -4], "size": [8, 1, 3] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-2, 3, -3], "size": [6, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-1, 4, -2], "size": [4, 1, 1] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-3, 2, -1], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-2, 3, -1], "size": [2, 1, 1] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-1, 4, -1], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [0, 5, -1], "size": [2, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [2, 2, -1], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [2, 3, -1], "size": [2, 1, 1] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [2, 4, -1], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-2, 3, 0], "size": [6, 1, 3] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-1, 4, 0], "size": [4, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-3, 2, 1], "size": [8, 1, 3] }
+      },
+      {
         "blockType": "LightAndShadowResources:BlackFloorBlock",
-        "region": { "min": [-1, 0, 0], "size": [2, 3, 2] }
-      },
-      {
-        "blockType": "LightAndShadowResources:WhiteCenterBlock",
-        "region": { "min": [-4, 2, -3], "size": [8, 1, 3] }
-      },
-      {
-        "blockType": "LightAndShadowResources:WhiteCenterBlock",
-        "region": { "min": [-3, 3, -2], "size": [6, 1, 1] }
-      },
-      {
-        "blockType": "LightAndShadowResources:WhiteCenterBlock",
-        "region": { "min": [-3, 3, -1], "size": [2, 1, 1] }
-      },
-      {
-        "blockType": "LightAndShadowResources:WhiteCenterBlock",
-        "region": { "min": [-2, 4, -1], "size": [4, 1, 4] }
-      },
-      {
-        "blockType": "LightAndShadowResources:WhiteCenterBlock",
-        "region": { "min": [2, 3, -1], "size": [1, 1, 4] }
-      },
-      {
-        "blockType": "LightAndShadowResources:WhiteCenterBlock",
-        "region": { "min": [-4, 2, 0], "size": [3, 1, 2] }
-      },
-      {
-        "blockType": "LightAndShadowResources:WhiteCenterBlock",
-        "region": { "min": [-3, 3, 0], "size": [1, 1, 3] }
-      },
-      {
-        "blockType": "LightAndShadowResources:WhiteCenterBlock",
-        "region": { "min": [-1, 5, 0], "size": [2, 1, 2] }
-      },
-      {
-        "blockType": "LightAndShadowResources:WhiteCenterBlock",
-        "region": { "min": [1, 2, 0], "size": [3, 1, 2] }
-      },
-      {
-        "blockType": "LightAndShadowResources:WhiteCenterBlock",
-        "region": { "min": [-4, 2, 2], "size": [8, 1, 3] }
-      },
-      {
-        "blockType": "LightAndShadowResources:WhiteCenterBlock",
-        "region": { "min": [-3, 3, 3], "size": [6, 1, 1] }
+        "region": { "min": [0, 0, -1], "size": [2, 3, 2] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 0, -3], "size": [8, 2, 3] }
+        "region": { "min": [-2, 0, -4], "size": [1, 1, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 3, -3], "size": [8, 3, 1] }
+        "region": { "min": [4, 0, -4], "size": [1, 1, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 3, -2], "size": [1, 1, 6] }
+        "region": { "min": [-3, 0, -2], "size": [1, 1, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 4, -2], "size": [8, 2, 1] }
+        "region": { "min": [-3, 0, -4], "size": [1, 1, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [3, 3, -2], "size": [1, 1, 6] }
+        "region": { "min": [-3, 1, -4], "size": [8, 1, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 4, -1], "size": [2, 1, 4] }
+        "region": { "min": [-3, 3, -4], "size": [8, 3, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 5, -1], "size": [8, 1, 1] }
+        "region": { "min": [-1, 0, -4], "size": [5, 1, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-1, 3, -1], "size": [3, 1, 1] }
+        "region": { "min": [-3, 0, -3], "size": [8, 2, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [2, 4, -1], "size": [2, 1, 4] }
+        "region": { "min": [-3, 3, -3], "size": [1, 1, 6] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 0, 0], "size": [3, 2, 2] }
+        "region": { "min": [-3, 4, -3], "size": [8, 2, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 5, 0], "size": [3, 1, 2] }
+        "region": { "min": [4, 3, -3], "size": [1, 1, 6] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-2, 3, 0], "size": [4, 1, 3] }
+        "region": { "min": [-3, 1, -2], "size": [8, 1, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [1, 0, 0], "size": [3, 2, 2] }
+        "region": { "min": [-3, 4, -2], "size": [2, 1, 4] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [1, 5, 0], "size": [3, 1, 2] }
+        "region": { "min": [-3, 5, -2], "size": [8, 1, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 0, 2], "size": [8, 2, 3] }
+        "region": { "min": [-2, 0, -2], "size": [7, 1, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 5, 2], "size": [8, 1, 1] }
+        "region": { "min": [3, 4, -2], "size": [2, 1, 4] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 4, 3], "size": [8, 2, 1] }
+        "region": { "min": [-3, 0, -1], "size": [3, 2, 2] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 3, 4], "size": [8, 3, 1] }
+        "region": { "min": [-3, 5, -1], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [0, 3, -1], "size": [2, 2, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [2, 0, -1], "size": [3, 2, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [2, 5, -1], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 0, 1], "size": [8, 2, 3] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 5, 1], "size": [8, 1, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 4, 2], "size": [8, 2, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 3, 3], "size": [8, 3, 1] }
       }
     ]
   }

--- a/assets/prefabs/structures/WhiteBlackTree.prefab
+++ b/assets/prefabs/structures/WhiteBlackTree.prefab
@@ -1,0 +1,127 @@
+{
+  "StructureTemplate": {},
+  "SpawnBlockRegions": {
+    "regionsToFill": [
+      {
+        "blockType": "LightAndShadowResources:BlackFloorBlock",
+        "region": { "min": [-1, 0, 0], "size": [2, 3, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-4, 2, -3], "size": [8, 1, 3] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-3, 3, -2], "size": [6, 1, 1] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-3, 3, -1], "size": [2, 1, 1] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-2, 4, -1], "size": [4, 1, 4] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [2, 3, -1], "size": [1, 1, 4] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-4, 2, 0], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-3, 3, 0], "size": [1, 1, 3] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-1, 5, 0], "size": [2, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [1, 2, 0], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-4, 2, 2], "size": [8, 1, 3] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-3, 3, 3], "size": [6, 1, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 0, -3], "size": [8, 2, 3] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 3, -3], "size": [8, 3, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 3, -2], "size": [1, 1, 6] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 4, -2], "size": [8, 2, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [3, 3, -2], "size": [1, 1, 6] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 4, -1], "size": [2, 1, 4] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 5, -1], "size": [8, 1, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-1, 3, -1], "size": [3, 1, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [2, 4, -1], "size": [2, 1, 4] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 0, 0], "size": [3, 2, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 5, 0], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-2, 3, 0], "size": [4, 1, 3] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [1, 0, 0], "size": [3, 2, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [1, 5, 0], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 0, 2], "size": [8, 2, 3] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 5, 2], "size": [8, 1, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 4, 3], "size": [8, 2, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 3, 4], "size": [8, 3, 1] }
+      }
+    ]
+  }
+}

--- a/assets/prefabs/structures/WhiteRedTree.prefab
+++ b/assets/prefabs/structures/WhiteRedTree.prefab
@@ -3,144 +3,160 @@
   "SpawnBlockRegions": {
     "regionsToFill": [
       {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-3, 2, -4], "size": [8, 1, 3] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-2, 3, -3], "size": [6, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-1, 4, -2], "size": [4, 1, 1] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-3, 2, -1], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-2, 3, -1], "size": [2, 1, 1] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-1, 4, -1], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [0, 5, -1], "size": [2, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [2, 2, -1], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [2, 3, -1], "size": [2, 1, 1] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [2, 4, -1], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-2, 3, 0], "size": [6, 1, 3] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-1, 4, 0], "size": [4, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-3, 2, 1], "size": [8, 1, 3] }
+      },
+      {
         "blockType": "LightAndShadowResources:RedFloorBlock",
-        "region": { "min": [-1, 0, -1], "size": [2, 5, 2] }
-      },
-      {
-        "blockType": "LightAndShadowResources:WhiteCenterBlock",
-        "region": { "min": [-4, 2, -4], "size": [8, 1, 3] }
-      },
-      {
-        "blockType": "LightAndShadowResources:WhiteCenterBlock",
-        "region": { "min": [-3, 3, -3], "size": [6, 1, 1] }
-      },
-      {
-        "blockType": "LightAndShadowResources:WhiteCenterBlock",
-        "region": { "min": [-3, 3, -2], "size": [1, 1, 4] }
-      },
-      {
-        "blockType": "LightAndShadowResources:WhiteCenterBlock",
-        "region": { "min": [-2, 4, -2], "size": [4, 1, 1] }
-      },
-      {
-        "blockType": "LightAndShadowResources:WhiteCenterBlock",
-        "region": { "min": [2, 3, -2], "size": [1, 1, 3] }
-      },
-      {
-        "blockType": "LightAndShadowResources:WhiteCenterBlock",
-        "region": { "min": [-4, 2, -1], "size": [3, 1, 2] }
-      },
-      {
-        "blockType": "LightAndShadowResources:WhiteCenterBlock",
-        "region": { "min": [-2, 4, -1], "size": [1, 1, 2] }
-      },
-      {
-        "blockType": "LightAndShadowResources:WhiteCenterBlock",
-        "region": { "min": [-1, 5, -1], "size": [2, 1, 2] }
-      },
-      {
-        "blockType": "LightAndShadowResources:WhiteCenterBlock",
-        "region": { "min": [1, 2, -1], "size": [3, 1, 2] }
-      },
-      {
-        "blockType": "LightAndShadowResources:WhiteCenterBlock",
-        "region": { "min": [1, 4, -1], "size": [1, 1, 2] }
-      },
-      {
-        "blockType": "LightAndShadowResources:WhiteCenterBlock",
-        "region": { "min": [-4, 2, 1], "size": [8, 1, 3] }
-      },
-      {
-        "blockType": "LightAndShadowResources:WhiteCenterBlock",
-        "region": { "min": [-2, 4, 1], "size": [4, 1, 1] }
-      },
-      {
-        "blockType": "LightAndShadowResources:WhiteCenterBlock",
-        "region": { "min": [1, 3, 1], "size": [2, 1, 1] }
-      },
-      {
-        "blockType": "LightAndShadowResources:WhiteCenterBlock",
-        "region": { "min": [-3, 3, 2], "size": [6, 1, 1] }
+        "region": { "min": [0, 0, -1], "size": [2, 3, 2] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 0, -4], "size": [8, 2, 3] }
+        "region": { "min": [-2, 0, -4], "size": [1, 1, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 3, -4], "size": [8, 3, 1] }
+        "region": { "min": [4, 0, -4], "size": [1, 1, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 3, -3], "size": [1, 1, 6] }
+        "region": { "min": [-3, 0, -2], "size": [1, 1, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 4, -3], "size": [8, 2, 1] }
+        "region": { "min": [-3, 0, -4], "size": [1, 1, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [3, 3, -3], "size": [1, 1, 6] }
+        "region": { "min": [-3, 1, -4], "size": [8, 1, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 4, -2], "size": [2, 1, 4] }
+        "region": { "min": [-3, 3, -4], "size": [8, 3, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 5, -2], "size": [8, 1, 1] }
+        "region": { "min": [-1, 0, -4], "size": [5, 1, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-2, 3, -2], "size": [4, 1, 1] }
+        "region": { "min": [-3, 0, -3], "size": [8, 2, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [2, 4, -2], "size": [2, 1, 4] }
+        "region": { "min": [-3, 3, -3], "size": [1, 1, 6] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 0, -1], "size": [3, 2, 2] }
+        "region": { "min": [-3, 4, -3], "size": [8, 2, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 5, -1], "size": [3, 1, 2] }
+        "region": { "min": [4, 3, -3], "size": [1, 1, 6] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-2, 3, -1], "size": [1, 1, 2] }
+        "region": { "min": [-3, 1, -2], "size": [8, 1, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [1, 0, -1], "size": [3, 2, 2] }
+        "region": { "min": [-3, 4, -2], "size": [2, 1, 4] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [1, 3, -1], "size": [1, 1, 2] }
+        "region": { "min": [-3, 5, -2], "size": [8, 1, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [1, 5, -1], "size": [3, 1, 2] }
+        "region": { "min": [-2, 0, -2], "size": [7, 1, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 0, 1], "size": [8, 2, 3] }
+        "region": { "min": [3, 4, -2], "size": [2, 1, 4] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 5, 1], "size": [8, 1, 1] }
+        "region": { "min": [-3, 0, -1], "size": [3, 2, 2] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-2, 3, 1], "size": [3, 1, 1] }
+        "region": { "min": [-3, 5, -1], "size": [3, 1, 2] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 4, 2], "size": [8, 2, 1] }
+        "region": { "min": [0, 3, -1], "size": [2, 2, 1] }
       },
       {
         "blockType": "engine:air",
-        "region": { "min": [-4, 3, 3], "size": [8, 3, 1] }
+        "region": { "min": [2, 0, -1], "size": [3, 2, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [2, 5, -1], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 0, 1], "size": [8, 2, 3] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 5, 1], "size": [8, 1, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 4, 2], "size": [8, 2, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-3, 3, 3], "size": [8, 3, 1] }
       }
     ]
   }

--- a/assets/prefabs/structures/WhiteRedTree.prefab
+++ b/assets/prefabs/structures/WhiteRedTree.prefab
@@ -1,0 +1,147 @@
+{
+  "StructureTemplate": {},
+  "SpawnBlockRegions": {
+    "regionsToFill": [
+      {
+        "blockType": "LightAndShadowResources:RedFloorBlock",
+        "region": { "min": [-1, 0, -1], "size": [2, 5, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-4, 2, -4], "size": [8, 1, 3] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-3, 3, -3], "size": [6, 1, 1] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-3, 3, -2], "size": [1, 1, 4] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-2, 4, -2], "size": [4, 1, 1] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [2, 3, -2], "size": [1, 1, 3] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-4, 2, -1], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-2, 4, -1], "size": [1, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-1, 5, -1], "size": [2, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [1, 2, -1], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [1, 4, -1], "size": [1, 1, 2] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-4, 2, 1], "size": [8, 1, 3] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-2, 4, 1], "size": [4, 1, 1] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [1, 3, 1], "size": [2, 1, 1] }
+      },
+      {
+        "blockType": "LightAndShadowResources:WhiteCenterBlock",
+        "region": { "min": [-3, 3, 2], "size": [6, 1, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 0, -4], "size": [8, 2, 3] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 3, -4], "size": [8, 3, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 3, -3], "size": [1, 1, 6] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 4, -3], "size": [8, 2, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [3, 3, -3], "size": [1, 1, 6] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 4, -2], "size": [2, 1, 4] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 5, -2], "size": [8, 1, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-2, 3, -2], "size": [4, 1, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [2, 4, -2], "size": [2, 1, 4] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 0, -1], "size": [3, 2, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 5, -1], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-2, 3, -1], "size": [1, 1, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [1, 0, -1], "size": [3, 2, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [1, 3, -1], "size": [1, 1, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [1, 5, -1], "size": [3, 1, 2] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 0, 1], "size": [8, 2, 3] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 5, 1], "size": [8, 1, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-2, 3, 1], "size": [3, 1, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 4, 2], "size": [8, 2, 1] }
+      },
+      {
+        "blockType": "engine:air",
+        "region": { "min": [-4, 3, 3], "size": [8, 3, 1] }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Templates are taken from #18 

Adds multiple structure templates for trees in the Light and Shadow
theme. The template naming follows the pattern:

```
<leaveColor><trunkColor>Tree
```

The following trees are added:
- black-red tree
- black-white tree
- red-white tree
- red-black tree
- white-black tree
- white-red tree

![image](https://user-images.githubusercontent.com/1448874/67097186-dcf81380-f1b9-11e9-8618-b7aaeda85daa.png)

Co-authored-by: Mohammad Darvish <mdschoolid@gmail.com>