### PR TITLE
feat: slimmer ammo slot

### DIFF
--- a/assets/skins/ammoHud.skin
+++ b/assets/skins/ammoHud.skin
@@ -3,6 +3,8 @@
     "elements": {
         "InventoryCell": {
             "background": "engine:area",
+            "fixed-width": 50,
+            "fixed-height": 50,
             "background-border": {
                 "top": 4,
                 "bottom": 4,


### PR DESCRIPTION
#### Summary

I made the ammo slot smaller, so it differs from the rest of the quickslot items.

#### How to test

1. Check https://github.com/Terasology/LightAndShadow/pull/142
2. Start a LAS game
3. Hold the bow so the ammo slot appears

#### Result

![image](https://user-images.githubusercontent.com/48293545/89038662-70fe2a80-d349-11ea-8d01-bb89c61d33c3.png)
