### PR TITLE
feat: coloring of Victory-Defeat Label

### DIFF
--- a/assets/skins/gameoverScreen.skin
+++ b/assets/skins/gameoverScreen.skin
@@ -82,6 +82,16 @@
         },
         "playerNames" : {
             "font" : "engine:NotoSans-Regular-Title"
+        },
+        "win" : {
+            "font" : "lightAndShadowResources:WickedQueen-Size72",
+            "text-color": "003867FF",
+            "text-shadowed" : false
+        },
+        "lose" : {
+            "font" : "lightAndShadowResources:WickedQueen-Size72",
+            "text-color": "670003FF",
+            "text-shadowed" : false
         }
     }
 }

--- a/assets/skins/gameoverScreen.skin
+++ b/assets/skins/gameoverScreen.skin
@@ -90,7 +90,7 @@
         },
         "lose" : {
             "font" : "lightAndShadowResources:WickedQueen-Size72",
-            "text-color": "670003FF",
+            "text-color": "460067FF",
             "text-shadowed" : false
         }
     }


### PR DESCRIPTION
## Purpose
The change of colors to the `gameOverResult` UILabel. When text is "Victory" its color is Blue, when "Defeat" its color is "Red"

## Changes made

Set the wanted colors to the appropriate new `families`.

## How to test

1. Check https://github.com/Terasology/LightAndShadow/pull/148
2. Start a LAS game
3. Choose a team
4. Open the developer tab and gain the enemy team's by writting `give` and `redflag` or `blackflag`
5. Score as many points as you need to finish up the game
6. The Game Over Screen will pop up when you score the last point

_Note:_ You can go to `LAUtils.java` and change `GOAL_SCORE` variable from `5` to `1`, so you need to score 1 point to end the game.

## Screenshot
![image](https://user-images.githubusercontent.com/48293545/91207308-3c477e00-e711-11ea-9a74-1a34410e4ec5.png)
