### PR TITLE
Disabled mode for restart button

### DIFF
--- a/assets/skins/gameoverScreen.skin
+++ b/assets/skins/gameoverScreen.skin
@@ -23,6 +23,11 @@
                     "background": "LightAndShadowResources:buttonRedPushed",
                     "text-shadowed" : false,
                     "text-color": "AAAA00FF"
+                },
+                "disabled": {
+                    "background": "lightAndShadowResources:3dBox",
+                    "text-shadowed" : false,
+                    "text-color": "E8E8E8FF"
                 }
             }
         },

--- a/assets/skins/gameoverScreen.skin
+++ b/assets/skins/gameoverScreen.skin
@@ -27,7 +27,7 @@
                 "disabled": {
                     "background": "lightAndShadowResources:3dBox",
                     "text-shadowed" : false,
-                    "text-color": "E8E8E8FF"
+                    "text-color": "515A5AFF"
                 }
             }
         },


### PR DESCRIPTION
### Contains
Part of  https://github.com/Terasology/LightAndShadow/pull/161 and adds the disabled mode to the UIButton which has to be used for the restart button.


### How to test
Join a single player or multiplayer game and when the game is over, for the first 10 seconds the disabled mode of the refresh button will be visible.

### Outstanding before merging
- [x] Disabled mode for UIButton.