### PR TITLE
chore: Adjust for changes in MovingBlocks/Terasology#4818

### DIFF
--- a/assets/prefabs/magicStaff.prefab
+++ b/assets/prefabs/magicStaff.prefab
@@ -8,7 +8,7 @@
         "usage": "IN_DIRECTION"
     },
     "Range": {
-        "value": 30.0
+        "range": 30.0
     },
     "FlagDropOnActivate": {}
 }


### PR DESCRIPTION
Adjust for rename of `RangeComponent#value` to `range`.

Depends on MovingBlocks/Terasology#4818.

Follow up to #70.
