### PR TITLE
fix: make yinyang blocks indestructible

### DIFF
--- a/assets/blocks/blackFloorBlock.block
+++ b/assets/blocks/blackFloorBlock.block
@@ -1,4 +1,5 @@
 {
+    "hardness" : 0,
     "tiles" : {
         "all" : "LightAndShadowResources:blackBlockFloor"
     }

--- a/assets/blocks/redFloorBlock.block
+++ b/assets/blocks/redFloorBlock.block
@@ -1,4 +1,5 @@
 {
+    "hardness" : 0,
     "tiles" : {
         "all" : "LightAndShadowResources:redBlockFloor"
     }


### PR DESCRIPTION
Like the team bases, the yinyang symbol in the center of the arena shouldn't be destructible.
This PR changes the hardness of the blocks used for the yinyang so that they become indestructible.