### PR TITLE
feat: balance weapon damage

### DIFF
--- a/deltas/CombatSystem/prefabs/items/crossbow.prefab
+++ b/deltas/CombatSystem/prefabs/items/crossbow.prefab
@@ -1,0 +1,5 @@
+{
+  "Item": {
+    "cooldownTime": 200
+  }
+}

--- a/deltas/CombatSystem/prefabs/items/spearItem.prefab
+++ b/deltas/CombatSystem/prefabs/items/spearItem.prefab
@@ -4,10 +4,10 @@
   },
   "Melee": {
     "primaryAttack": true,
-    "range": 2
+    "range": 4
   },
   "RandomDamage": {
-    "minDamage": 40,
-    "maxDamage": 60
+    "minDamage": 20,
+    "maxDamage": 30
   }
 }

--- a/deltas/CombatSystem/prefabs/items/staff.prefab
+++ b/deltas/CombatSystem/prefabs/items/staff.prefab
@@ -1,5 +1,5 @@
 {
   "Item": {
-    "cooldownTime": 300
+    "cooldownTime": 250
   }
 }

--- a/deltas/CombatSystem/prefabs/items/staff.prefab
+++ b/deltas/CombatSystem/prefabs/items/staff.prefab
@@ -1,5 +1,5 @@
 {
   "Item": {
-    "cooldownTime": 250
+    "cooldownTime": 300
   }
 }

--- a/deltas/CombatSystem/prefabs/items/sword.prefab
+++ b/deltas/CombatSystem/prefabs/items/sword.prefab
@@ -2,6 +2,10 @@
   "Item": {
     "cooldownTime": 500
   },
+  "Melee": {
+    "primaryAttack": true,
+    "range": 2
+  },
   "RandomDamage": {
     "minDamage": 20,
     "maxDamage": 30

--- a/deltas/CombatSystem/prefabs/items/sword.prefab
+++ b/deltas/CombatSystem/prefabs/items/sword.prefab
@@ -4,6 +4,6 @@
   },
   "RandomDamage": {
     "minDamage": 20,
-    "maxDamage": 25
+    "maxDamage": 30
   }
 }

--- a/deltas/CombatSystem/prefabs/items/waraxe.prefab
+++ b/deltas/CombatSystem/prefabs/items/waraxe.prefab
@@ -3,7 +3,7 @@
     "cooldownTime": 1000
   },
   "RandomDamage": {
-    "minDamage": 30,
-    "maxDamage": 40
+    "minDamage": 40,
+    "maxDamage": 60
   }
 }

--- a/deltas/CombatSystem/prefabs/projectiles/arrow.prefab
+++ b/deltas/CombatSystem/prefabs/projectiles/arrow.prefab
@@ -1,5 +1,5 @@
 {
   "Hurting": {
-    "amount": 100
+    "amount": 20
   }
 }


### PR DESCRIPTION
This is an attempt to balance the weapons a bit better.
We do have different dimensions along which we can assess the (combat) value of a weapon:
- range
- damage
- ammo requirements
- cooldown


| Weapon                 | Range | Ammo? | Damage | Cooldown | Time to Kill | (Combat) Value |
|--------------------------|----------|------------ |------------|---------------|-----------------|-----------------------|
| Sword                    | 2         | no          | 20-30     | 500           | 2000 | ? |
| Waraxe                  | 2         | no          | 40-60     | 1000         | 2000 | ? |
| Staff (Melee)          | 2         | no          | ?            | ?               | ?       | ? |
| Staff (Fireball)        | long    | infinite    | 10          | 300           | 3000 | ? |
| Spear (Melee)        | 4         | no          | 20-30     | 1000         | 4000 | ? |
| Spear (Throw)        | long    | yes (self) | 100       | 100 (slot change) | 100 | ? |
| Crossbow (Arrows) | long    | finite      | 20          | 200           | 1000 | ? |

(Time to kill is `ceil(playerMaxHealth / damage) * cooldown` with `playerMaxHealth = 100`)

Melee weapons - sword, axe (, staff, spear)
- Con: need to get close to enemy
- Pro: acceptable to high damage

Ranged, ammo-less weapons - staff (fireball)
- Con: low damage, hard to hit opponent
- Pro: endless ammo, acceptable cooldown, long range

Ranged, ammo-requiring weapons - Crossbow (arrows)
- Con: requires ammo, hard to hit opponent
- Pro: low cool down, acceptable damage, long range

Ranged, pick-up weapons - Spear (throw)
- Con: needs to be picked up, hard to hit opponent
- Pro: very high damage, long range

How can we estimate a reasonable (combat) value based on these properties?
Based on the formula we come up with, I'd like to derive the monetary value of the items.